### PR TITLE
Refactor auth.guard.ts to Support Public Route Decorators

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,11 +8,14 @@ import {
 } from '@nestjs/common';
 import { AuthRequest } from './dto/auth-request';
 import { AuthService } from './auth.service';
+import { Public } from 'src/decorators/public.decorator';
 
+// @Public() // either add the public decorator per route
 @Controller('api/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @Public() // or add the public decorator per method
   @Post()
   @HttpCode(HttpStatus.CREATED)
   create(@Body() request: AuthRequest) {

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -8,15 +8,27 @@ import {
 import { Observable } from 'rxjs';
 
 import * as jwt from 'jsonwebtoken';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from 'src/decorators/public.decorator';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   private readonly logger = new Logger(AuthGuard.name);
 
+  constructor(private reflector: Reflector) {}
+
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     this.logger.log(AuthGuard.name);
+
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) return true;
+
     const request = context.switchToHttp().getRequest();
     const authHeader = request.headers['authorization'];
 

--- a/src/decorators/public.decorator.ts
+++ b/src/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);


### PR DESCRIPTION
Updated auth.guard.ts to allow handling of public routes by accepting and processing @Public() decorators.